### PR TITLE
Return proper error code on success.

### DIFF
--- a/Compiler/Program.cs
+++ b/Compiler/Program.cs
@@ -23,7 +23,7 @@ namespace Compiler
                 return ParseFile(args[0], args[1], args[2]);
             }
 
-            return 1;
+            return 0;
         }
 
         private static IEnumerable<string> ParseAllFiles(string path)


### PR DESCRIPTION
Returning an error code as 1 would indicate that the program did not succeed in its task.
This happens regardless if the compilation succeeded or not.